### PR TITLE
Initial support for windows and mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,26 +4,39 @@ Build Bonita from sources
 [![Linux build](https://img.shields.io/travis/Bonitasoft-Community/Build-Bonita/master?label=Linux%20build&logo=travis)](https://travis-ci.org/Bonitasoft-Community/Build-Bonita)
 
 
-The script to build Bonita Engine, Portal and Studio from official sources
+Overview
 ------------------------------------------------------------------------------
 
-This script is designed to build the whole Bonita Community Edition solution from sources publicly available.
+A bash script is provided to build the whole Bonita Community Edition solution from sources publicly available.
 
 
 Requirements
 ------------
 
 - Disk space: around 15 GB free space. Around 4 GB of dependencies will be downloaded (sources, Maven dependencies, ...). A fast internet connection is recommended.
-- OS: Linux. This script is designed for Linux Operating System. You are of course free to fork it for Windows or Mac.
+- OS: This script is designed for Linux Operating System. It is not regularly tested on Windows or Mac but should work on these OS.
 - Maven: 3.6.x
 - Java: Oracle/OpenJDK Java 8 (⚠ you cannot use Java 11 to build Bonita)
+
 
 
 Instructions
 ------------
 1. Place this script in an empty folder
 1. Run `bash build-script.sh` in a terminal
-1. Once finished, you will find a working build of Bonita in: `bonita-studio/all-in-one/target`.
+1. Once finished, the following binaries are available
+  - studio: `bonita-studio/all-in-one/target` (only zip archive, no installer)
+  - tomcat bundle: `bonita-distrib/bundle/tomcat/target`
+
+**Notes**
+- If you want to make 100% sure that you do a clean build from scratch, run the following commands:
+```bash
+rm -rf ~/.m2/repository/org/bonitasoft/
+rm -rf ~/.gradle/caches
+find -type d -name ".gradle" -prune -exec rm -rf {} \;
+find -type d -name target -prune -exec rm -rf {} \;
+```
+
 
 **Notes**
 - no tests are run by the script (at least no backend tests)
@@ -37,6 +50,7 @@ This script has been manually tested with the following environment:
 - Debian GNU/Linux Buster
 - Maven 3.6.0
 - Oracle Java 1.8.0_221
+
 
 In addition, a Travis CI Ubuntu Xenial build runs on master branch push and PR creation/update
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Instructions
 1. Place this script in an empty folder
 1. Run `bash build-script.sh` in a terminal
 1. Once finished, the following binaries are available
-  - studio: `bonita-studio/all-in-one/target` (only zip archive, no installer)
-  - tomcat bundle: `bonita-distrib/bundle/tomcat/target`
+    1. studio: `bonita-studio/all-in-one/target` (only zip archive, no installer)
+    1. tomcat bundle: `bonita-distrib/bundle/tomcat/target`
 
 **Notes**
 - If you want to make 100% sure that you do a clean build from scratch, run the following commands:

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Requirements
 ------------
 
 - Disk space: around 15 GB free space. Around 4 GB of dependencies will be downloaded (sources, Maven dependencies, ...). A fast internet connection is recommended.
-- OS: This script is designed for Linux Operating System. It is not regularly tested on Windows or Mac but should work on these OS.
-- Maven: 3.6.x
-- Java: Oracle/OpenJDK Java 8 (⚠ you cannot use Java 11 to build Bonita)
+- OS: this script is designed for Linux Operating System. It is not regularly tested on Windows or Mac but should work on these OS.
+- Maven: 3.6.x.
+- Java: Oracle/OpenJDK Java 8 (⚠ you cannot use Java 11 to build Bonita).
 
 
 
@@ -32,6 +32,8 @@ Instructions
 - If you want to make 100% sure that you do a clean build from scratch, run the following commands:
 ```bash
 rm -rf ~/.m2/repository/org/bonitasoft/
+rm -rf ~/.m2/repository/.cache
+rm -rf ~/.m2/repository/.meta
 rm -rf ~/.gradle/caches
 find -type d -name ".gradle" -prune -exec rm -rf {} \;
 find -type d -name target -prune -exec rm -rf {} \;
@@ -39,8 +41,8 @@ find -type d -name target -prune -exec rm -rf {} \;
 
 
 **Notes**
-- no tests are run by the script (at least no backend tests)
-- the script does not produce Studio installers
+- No tests are run by the script (at least no back end tests).
+- The script does not produce Studio installers (required license for proprietary software).
 
 
 Test environment

--- a/build-script.sh
+++ b/build-script.sh
@@ -329,40 +329,40 @@ detectStudioDependenciesVersions() {
 }
 
 detectConnectorsVersions() {
-  echo "Detecting Connectors versions"
-  local studioPom=`curl -sS -X GET https://raw.githubusercontent.com/bonitasoft/bonita-studio/${BONITA_BPM_VERSION}/bundles/plugins/org.bonitasoft.studio.connectors/pom.xml`
-  CONNECTOR_VERSION_ALFRESCO=`echo "${studioPom}" | grep connector.version.alfresco | grep -v '<version>' | sed 's@.*>\(.*\)<.*@\1@g'`
-  echo "CONNECTOR_VERSION_ALFRESCO: ${CONNECTOR_VERSION_ALFRESCO}"
+    echo "Detecting Connectors versions"
+    local studioPom=`curl -sS -X GET https://raw.githubusercontent.com/bonitasoft/bonita-studio/${BONITA_BPM_VERSION}/bundles/plugins/org.bonitasoft.studio.connectors/pom.xml`
+    CONNECTOR_VERSION_ALFRESCO=`echo "${studioPom}" | grep connector.version.alfresco | grep -v '<version>' | sed 's@.*>\(.*\)<.*@\1@g'`
+    echo "CONNECTOR_VERSION_ALFRESCO: ${CONNECTOR_VERSION_ALFRESCO}"
 
-  CONNECTOR_VERSION_CMIS=`echo "${studioPom}" | grep connector.version.cmis | grep -v '<version>' | sed 's@.*>\(.*\)<.*@\1@g'`
-  echo "CONNECTOR_VERSION_CMIS: ${CONNECTOR_VERSION_CMIS}"
+    CONNECTOR_VERSION_CMIS=`echo "${studioPom}" | grep connector.version.cmis | grep -v '<version>' | sed 's@.*>\(.*\)<.*@\1@g'`
+    echo "CONNECTOR_VERSION_CMIS: ${CONNECTOR_VERSION_CMIS}"
 
-  CONNECTOR_VERSION_DATABASE=`echo "${studioPom}" | grep connector.version.database | grep -v '<version>' | sed 's@.*>\(.*\)<.*@\1@g'`
-  echo "CONNECTOR_VERSION_DATABASE: ${CONNECTOR_VERSION_DATABASE}"
+    CONNECTOR_VERSION_DATABASE=`echo "${studioPom}" | grep connector.version.database | grep -v '<version>' | sed 's@.*>\(.*\)<.*@\1@g'`
+    echo "CONNECTOR_VERSION_DATABASE: ${CONNECTOR_VERSION_DATABASE}"
 
-  CONNECTOR_VERSION_EMAIL=`echo "${studioPom}" | grep connector.version.email | grep -v '<version>' | sed 's@.*>\(.*\)<.*@\1@g'`
-  echo "CONNECTOR_VERSION_EMAIL: ${CONNECTOR_VERSION_EMAIL}"
+    CONNECTOR_VERSION_EMAIL=`echo "${studioPom}" | grep connector.version.email | grep -v '<version>' | sed 's@.*>\(.*\)<.*@\1@g'`
+    echo "CONNECTOR_VERSION_EMAIL: ${CONNECTOR_VERSION_EMAIL}"
 
-  CONNECTOR_VERSION_GOOGLE_CALENDAR_V3=`echo "${studioPom}" | grep google-calendar-v3 | grep -v '<version>' | grep -v 'impl' | sed 's@.*>\(.*\)<.*@\1@g'`
-  echo "CONNECTOR_VERSION_GOOGLE_CALENDAR_V3: ${CONNECTOR_VERSION_GOOGLE_CALENDAR_V3}"
+    CONNECTOR_VERSION_GOOGLE_CALENDAR_V3=`echo "${studioPom}" | grep google-calendar-v3 | grep -v '<version>' | grep -v 'impl' | sed 's@.*>\(.*\)<.*@\1@g'`
+    echo "CONNECTOR_VERSION_GOOGLE_CALENDAR_V3: ${CONNECTOR_VERSION_GOOGLE_CALENDAR_V3}"
 
-  CONNECTOR_VERSION_LDAP=`echo "${studioPom}" | grep connector.version.ldap | grep -v '<version>' | sed 's@.*>\(.*\)<.*@\1@g'`
-  echo "CONNECTOR_VERSION_LDAP: ${CONNECTOR_VERSION_LDAP}"
+    CONNECTOR_VERSION_LDAP=`echo "${studioPom}" | grep connector.version.ldap | grep -v '<version>' | sed 's@.*>\(.*\)<.*@\1@g'`
+    echo "CONNECTOR_VERSION_LDAP: ${CONNECTOR_VERSION_LDAP}"
 
-  CONNECTOR_VERSION_REST=`echo "${studioPom}" | grep connector.version.rest | grep -v '<version>' | sed 's@.*>\(.*\)<.*@\1@g'`
-  echo "CONNECTOR_VERSION_REST: ${CONNECTOR_VERSION_REST}"
+    CONNECTOR_VERSION_REST=`echo "${studioPom}" | grep connector.version.rest | grep -v '<version>' | sed 's@.*>\(.*\)<.*@\1@g'`
+    echo "CONNECTOR_VERSION_REST: ${CONNECTOR_VERSION_REST}"
 
-  CONNECTOR_VERSION_SALESFORCE=`echo "${studioPom}" | grep connector.version.salesforce | grep -v '<version>' | sed 's@.*>\(.*\)<.*@\1@g'`
-  echo "CONNECTOR_VERSION_SALESFORCE: ${CONNECTOR_VERSION_SALESFORCE}"
+    CONNECTOR_VERSION_SALESFORCE=`echo "${studioPom}" | grep connector.version.salesforce | grep -v '<version>' | sed 's@.*>\(.*\)<.*@\1@g'`
+    echo "CONNECTOR_VERSION_SALESFORCE: ${CONNECTOR_VERSION_SALESFORCE}"
 
-  CONNECTOR_VERSION_SCRIPTING=`echo "${studioPom}" | grep connector.version.scripting | grep -v '<version>' | sed 's@.*>\(.*\)<.*@\1@g'`
-  echo "CONNECTOR_VERSION_SCRIPTING: ${CONNECTOR_VERSION_SCRIPTING}"
+    CONNECTOR_VERSION_SCRIPTING=`echo "${studioPom}" | grep connector.version.scripting | grep -v '<version>' | sed 's@.*>\(.*\)<.*@\1@g'`
+    echo "CONNECTOR_VERSION_SCRIPTING: ${CONNECTOR_VERSION_SCRIPTING}"
 
-  CONNECTOR_VERSION_TWITTER=`echo "${studioPom}" | grep connector.version.twitter | grep -v '<version>' | sed 's@.*>\(.*\)<.*@\1@g'`
-  echo "CONNECTOR_VERSION_TWITTER: ${CONNECTOR_VERSION_TWITTER}"
+    CONNECTOR_VERSION_TWITTER=`echo "${studioPom}" | grep connector.version.twitter | grep -v '<version>' | sed 's@.*>\(.*\)<.*@\1@g'`
+    echo "CONNECTOR_VERSION_TWITTER: ${CONNECTOR_VERSION_TWITTER}"
 
-  CONNECTOR_VERSION_WEBSERVICE=`echo "${studioPom}" | grep connector.version.webservice | grep -v '<version>' | sed 's@.*>\(.*\)<.*@\1@g'`
-  echo "CONNECTOR_VERSION_WEBSERVICE: ${CONNECTOR_VERSION_WEBSERVICE}"
+    CONNECTOR_VERSION_WEBSERVICE=`echo "${studioPom}" | grep connector.version.webservice | grep -v '<version>' | sed 's@.*>\(.*\)<.*@\1@g'`
+    echo "CONNECTOR_VERSION_WEBSERVICE: ${CONNECTOR_VERSION_WEBSERVICE}"
 }
 
 detectWebPagesDependenciesVersions() {

--- a/build-script.sh
+++ b/build-script.sh
@@ -5,14 +5,8 @@ set -e
 set +o nounset
 
 
-# If you want to make 100% sure that you do a clean build from scratch:
-# rm -rf ~/.m2/repository/org/bonitasoft/
 # rm -rf ~/.m2/repository/.cache
 # rm -rf ~/.m2/repository/.meta
-# rm -rf ~/.gradle/caches
-# find -type d -name ".gradle" -prune -exec rm -rf {} \;
-# find -type d -name target -prune -exec rm -rf {} \;
-
 # Workaround for at least Debian Buster
 # Require to build bonita-portal-js due to issue with PhantomJS launched by Karma
 # See https://github.com/ariya/phantomjs/issues/14520

--- a/build-script.sh
+++ b/build-script.sh
@@ -381,7 +381,6 @@ detectWebPagesDependenciesVersions() {
 ########################################################################################################################
 logBuildSettings
 checkPrerequisites
-exit 12
 
 # List of repositories on https://github.com/bonitasoft that you don't need to build
 # Note that archived repositories are not listed here, as they are only required to build old Bonita versions

--- a/build-script.sh
+++ b/build-script.sh
@@ -80,7 +80,7 @@ checkout() {
 	# The artifact include Ant Maven plugin to update the platform.target file but it is not executed before Tycho is executed and read the incorrect URL.
 	if [[ "$repository_name" == "bonita-studio" ]]; then
 		echo "WARN: workaround on $repository_name - fix platform.target URL"
-		sed -i "s,${STUDIO_P2_URL_INTERNAL_TO_REPLACE},${STUDIO_P2_URL},g" platform/platform.target
+		sed -i "" "s,${STUDIO_P2_URL_INTERNAL_TO_REPLACE},${STUDIO_P2_URL},g" platform/platform.target
 	fi
 }
 
@@ -241,6 +241,7 @@ checkPrerequisites() {
 		if [[ "${BONITA_BUILD_STUDIO_SKIP}" == "false" ]]; then
             # Test that x server is running. Required to generate Bonita Studio models
             # Can be ignored if Studio is build without the "generate" Maven profile
+
             if ! xset q &>/dev/null; then
                 echo "No X server at \$DISPLAY [$DISPLAY]" >&2
                 exit 1

--- a/build-script.sh
+++ b/build-script.sh
@@ -4,9 +4,6 @@ set -u
 set -e
 set +o nounset
 
-
-# rm -rf ~/.m2/repository/.cache
-# rm -rf ~/.m2/repository/.meta
 # Workaround for at least Debian Buster
 # Require to build bonita-portal-js due to issue with PhantomJS launched by Karma
 # See https://github.com/ariya/phantomjs/issues/14520
@@ -38,121 +35,121 @@ STUDIO_P2_URL_INTERNAL_TO_REPLACE=http://repositories.rd.lan/p2/4.10.1
 # - Tag name (optional)
 # - Checkout folder name (optional)
 checkout() {
-	# We need at least one parameter (the repository name) and no more than three (repository name, tag name and checkout folder name)
-	if [ "$#" -lt 1 ] || [ "$#" -gt 3 ]; then
-		echo "Incorrect number of parameters: $@"
-		exit 1
-	fi
+    # We need at least one parameter (the repository name) and no more than three (repository name, tag name and checkout folder name)
+    if [ "$#" -lt 1 ] || [ "$#" -gt 3 ]; then
+        echo "Incorrect number of parameters: $@"
+        exit 1
+    fi
 
-	repository_name="$1"
+    repository_name="$1"
 
-	if [ "$#" -ge 2 ]; then
-		tag_name="$2"
-	else
-		# If we don't have a tag name assume that the tag is named with the Bonita version
-		tag_name=$BONITA_BPM_VERSION
-	fi
-	echo "============================================================"
-	echo "Processing ${repository_name} ${tag_name}"
-	echo "============================================================"
+    if [ "$#" -ge 2 ]; then
+        tag_name="$2"
+    else
+        # If we don't have a tag name assume that the tag is named with the Bonita version
+        tag_name=$BONITA_BPM_VERSION
+    fi
+    echo "============================================================"
+    echo "Processing ${repository_name} ${tag_name}"
+    echo "============================================================"
 
-	if [ "$#" -eq 3 ]; then
-		checkout_folder_name="$3"
-	else
-		# If no checkout folder path is provided use the repository name as destination folder name
-		checkout_folder_name="$repository_name"
-	fi
+    if [ "$#" -eq 3 ]; then
+        checkout_folder_name="$3"
+    else
+        # If no checkout folder path is provided use the repository name as destination folder name
+        checkout_folder_name="$repository_name"
+    fi
 
-  # If we don't already clone the repository do it
-  if [ ! -d "$checkout_folder_name/.git" ]; then
-	  git clone "https://github.com/bonitasoft/$repository_name.git" $checkout_folder_name
-	fi
-	# Ensure we fetch all the tags and that we are on the appropriate one
-	git -C $checkout_folder_name fetch --tags
-	git -C $checkout_folder_name reset --hard tags/$tag_name
+    # If we don't already clone the repository do it
+    if [ ! -d "$checkout_folder_name/.git" ]; then
+      git clone "https://github.com/bonitasoft/$repository_name.git" $checkout_folder_name
+    fi
+    # Ensure we fetch all the tags and that we are on the appropriate one
+    git -C $checkout_folder_name fetch --tags
+    git -C $checkout_folder_name reset --hard tags/$tag_name
 
-	# Move to the repository clone folder (required to run Maven/Gradle wrapper)
-	cd $checkout_folder_name
+    # Move to the repository clone folder (required to run Maven/Gradle wrapper)
+    cd $checkout_folder_name
 
-	# Workarounds
-	# FIXME: remove temporary workaround added to make sure that we use public repository (Bonita internal tracker issue id: BST-463)
-	# Issue is related to Tycho target-platform-configuration plugin that rely on the artifact org.bonitasoft.studio:platform.
-	# The artifact include Ant Maven plugin to update the platform.target file but it is not executed before Tycho is executed and read the incorrect URL.
-	if [[ "$repository_name" == "bonita-studio" ]]; then
-		echo "WARN: workaround on $repository_name - fix platform.target URL"
-		sed -i "" "s,${STUDIO_P2_URL_INTERNAL_TO_REPLACE},${STUDIO_P2_URL},g" platform/platform.target
-	fi
+    # Workarounds
+    # FIXME: remove temporary workaround added to make sure that we use public repository (Bonita internal tracker issue id: BST-463)
+    # Issue is related to Tycho target-platform-configuration plugin that rely on the artifact org.bonitasoft.studio:platform.
+    # The artifact include Ant Maven plugin to update the platform.target file but it is not executed before Tycho is executed and read the incorrect URL.
+    if [[ "$repository_name" == "bonita-studio" ]]; then
+        echo "WARN: workaround on $repository_name - fix platform.target URL"
+        sed -i "" "s,${STUDIO_P2_URL_INTERNAL_TO_REPLACE},${STUDIO_P2_URL},g" platform/platform.target
+    fi
 }
 
 run_maven_with_standard_system_properties() {
-	build_command="$build_command -Dengine.version=$BONITA_BPM_VERSION -Dfilters.version=$BONITA_BPM_VERSION -Dp2MirrorUrl=${STUDIO_P2_URL}"
-	echo "[DEBUG] Running build command: $build_command"
-	eval "$build_command"
-	# Go back to script folder (checkout move current directory to project checkout folder.
-	cd ..
+    build_command="$build_command -Dengine.version=$BONITA_BPM_VERSION -Dfilters.version=$BONITA_BPM_VERSION -Dp2MirrorUrl=${STUDIO_P2_URL}"
+    echo "[DEBUG] Running build command: $build_command"
+    eval "$build_command"
+    # Go back to script folder (checkout move current directory to project checkout folder.
+    cd ..
 }
 
 run_gradle_with_standard_system_properties() {
-	echo "[DEBUG] Running build command: $build_command"
-	eval "$build_command"
-	# Go back to script folder (checkout move current directory to project checkout folder.
-	cd ..
+    echo "[DEBUG] Running build command: $build_command"
+    eval "$build_command"
+    # Go back to script folder (checkout move current directory to project checkout folder.
+    cd ..
 }
 
 # FIXME: should be replaced in all project by Maven wrapper
 build_maven() {
-	build_command="mvn"
+    build_command="mvn"
 }
 
 build_maven_wrapper() {
-	build_command="./mvnw"
+    build_command="./mvnw"
 }
 
 build_gradle_wrapper() {
-	build_command="./gradlew"
+    build_command="./gradlew"
 }
 
 build_quiet_if_requested() {
-	if [[ "${BONITA_BUILD_QUIET}" == "true" ]]; then
-		echo "Configure quiet build"
-		build_command="$build_command --quiet"
-	fi
+    if [[ "${BONITA_BUILD_QUIET}" == "true" ]]; then
+        echo "Configure quiet build"
+        build_command="$build_command --quiet"
+    fi
 }
 
 build() {
-	build_command="$build_command build"
+    build_command="$build_command build"
 }
 
 publishToMavenLocal() {
-	build_command="$build_command publishToMavenLocal"
+    build_command="$build_command publishToMavenLocal"
 }
 
 clean() {
-	if [[ "${BONITA_BUILD_NO_CLEAN}" == "true" ]]; then
-		echo "Configure build to skip clean task"
-	else
-		build_command="$build_command clean"
-	fi
+    if [[ "${BONITA_BUILD_NO_CLEAN}" == "true" ]]; then
+        echo "Configure build to skip clean task"
+    else
+        build_command="$build_command clean"
+    fi
 }
 
 install() {
-	build_command="$build_command install"
+    build_command="$build_command install"
 }
 
 verify() {
-	build_command="$build_command verify"
+    build_command="$build_command verify"
 }
 
 skiptest() {
-	build_command="$build_command -DskipTests"
+    build_command="$build_command -DskipTests"
 }
 
 gradle_test_skip() {
-	build_command="$build_command -x test"
+    build_command="$build_command -x test"
 }
 
 profile() {
-	build_command="$build_command -P$1"
+    build_command="$build_command -P$1"
 }
 
 #FIXME: should be replaced in all projects by Maven wrapper
@@ -160,13 +157,13 @@ profile() {
 # - Git repository name
 # - Branch name (optional)
 build_maven_install_skiptest() {
-	checkout "$@"
-	build_maven
-	build_quiet_if_requested
-	clean
-	install
-	skiptest
-	run_maven_with_standard_system_properties
+    checkout "$@"
+    build_maven
+    build_quiet_if_requested
+    clean
+    install
+    skiptest
+    run_maven_with_standard_system_properties
 }
 
 # params:
@@ -174,41 +171,41 @@ build_maven_install_skiptest() {
 # - Profile name
 build_maven_wrapper_verify_skiptest_with_profile()
 {
-	checkout $1
-	build_maven_wrapper
-	build_quiet_if_requested
-	clean
-	verify
-	skiptest
-	profile $2
-	run_maven_with_standard_system_properties
+    checkout $1
+    build_maven_wrapper
+    build_quiet_if_requested
+    clean
+    verify
+    skiptest
+    profile $2
+    run_maven_with_standard_system_properties
 }
 
 # params:
 # - Git repository name
 build_maven_wrapper_install_skiptest()
 {
-	checkout "$@"
-	# FIXME: required to build UID
-	# This has been fixed in UID 1.9.56, see https://github.com/bonitasoft/bonita-ui-designer/commit/edf0a0c7f943e8f215890550247d61eba14932c6
-	# To be removed when we will build newest UID versions
-	chmod u+x mvnw
-	build_maven_wrapper
-	build_quiet_if_requested
-	clean
-	install
-	skiptest
-	run_maven_with_standard_system_properties
+    checkout "$@"
+    # FIXME: required to build UID
+    # This has been fixed in UID 1.9.56, see https://github.com/bonitasoft/bonita-ui-designer/commit/edf0a0c7f943e8f215890550247d61eba14932c6
+    # To be removed when we will build newest UID versions
+    chmod u+x mvnw
+    build_maven_wrapper
+    build_quiet_if_requested
+    clean
+    install
+    skiptest
+    run_maven_with_standard_system_properties
 }
 
 build_gradle_wrapper_test_skip_publishToMavenLocal() {
-	checkout "$@"
-	build_gradle_wrapper
-	build_quiet_if_requested
-	clean
-	gradle_test_skip
-	publishToMavenLocal
-	run_gradle_with_standard_system_properties
+    checkout "$@"
+    build_gradle_wrapper
+    build_quiet_if_requested
+    clean
+    gradle_test_skip
+    publishToMavenLocal
+    run_gradle_with_standard_system_properties
 }
 
 ########################################################################################################################
@@ -237,8 +234,8 @@ detectOS() {
 checkPrerequisites() {
     detectOS
 
-	if [[ "${OS_IS_LINUX}" == "true" ]]; then
-		if [[ "${BONITA_BUILD_STUDIO_SKIP}" == "false" ]]; then
+    if [[ "${OS_IS_LINUX}" == "true" ]]; then
+        if [[ "${BONITA_BUILD_STUDIO_SKIP}" == "false" ]]; then
             # Test that x server is running. Required to generate Bonita Studio models
             # Can be ignored if Studio is build without the "generate" Maven profile
 
@@ -247,8 +244,8 @@ checkPrerequisites() {
                 exit 1
             fi
             echo "  > X server running correctly"
-    	fi
-	fi
+        fi
+    fi
 
     # Test that Maven exists
     # FIXME: remove once all projects includes Maven wrapper
@@ -319,16 +316,16 @@ checkJavaVersion() {
 ########################################################################################################################
 
 detectStudioDependenciesVersions() {
-	echo "Detecting Studio dependencies versions"
-	local studioPom=`curl -sS -X GET https://raw.githubusercontent.com/bonitasoft/bonita-studio/${BONITA_BPM_VERSION}/pom.xml`
+    echo "Detecting Studio dependencies versions"
+    local studioPom=`curl -sS -X GET https://raw.githubusercontent.com/bonitasoft/bonita-studio/${BONITA_BPM_VERSION}/pom.xml`
 
-	STUDIO_IMAGE_OVERLAY_PLUGIN_VERSION=`echo "${studioPom}" | grep image-overlay-plugin.version | grep -v '<version>' | sed 's@.*>\(.*\)<.*@\1@g'`
-	STUDIO_UID_VERSION=`echo "${studioPom}" | grep ui.designer.version | sed 's@.*>\(.*\)<.*@\1@g'`
-	STUDIO_WATCHDOG_VERSION=`echo "${studioPom}" | grep watchdog.version | sed 's@.*>\(.*\)<.*@\1@g'`
+    STUDIO_IMAGE_OVERLAY_PLUGIN_VERSION=`echo "${studioPom}" | grep image-overlay-plugin.version | grep -v '<version>' | sed 's@.*>\(.*\)<.*@\1@g'`
+    STUDIO_UID_VERSION=`echo "${studioPom}" | grep ui.designer.version | sed 's@.*>\(.*\)<.*@\1@g'`
+    STUDIO_WATCHDOG_VERSION=`echo "${studioPom}" | grep watchdog.version | sed 's@.*>\(.*\)<.*@\1@g'`
 
-	echo "STUDIO_IMAGE_OVERLAY_PLUGIN_VERSION: ${STUDIO_IMAGE_OVERLAY_PLUGIN_VERSION}"
-	echo "STUDIO_UID_VERSION: ${STUDIO_UID_VERSION}"
-	echo "STUDIO_WATCHDOG_VERSION: ${STUDIO_WATCHDOG_VERSION}"
+    echo "STUDIO_IMAGE_OVERLAY_PLUGIN_VERSION: ${STUDIO_IMAGE_OVERLAY_PLUGIN_VERSION}"
+    echo "STUDIO_UID_VERSION: ${STUDIO_UID_VERSION}"
+    echo "STUDIO_WATCHDOG_VERSION: ${STUDIO_WATCHDOG_VERSION}"
 }
 
 detectConnectorsVersions() {
@@ -369,11 +366,11 @@ detectConnectorsVersions() {
 }
 
 detectWebPagesDependenciesVersions() {
-	echo "Detecting web-pages dependencies versions"
-	local webPagesGradleBuild=`curl -sS -X GET https://raw.githubusercontent.com/bonitasoft/bonita-web-pages/${BONITA_BPM_VERSION}/build.gradle`
+    echo "Detecting web-pages dependencies versions"
+    local webPagesGradleBuild=`curl -sS -X GET https://raw.githubusercontent.com/bonitasoft/bonita-web-pages/${BONITA_BPM_VERSION}/build.gradle`
 
-	WEB_PAGES_UID_VERSION=`echo "${webPagesGradleBuild}" | tr -s "[:blank:]" | tr -d "\n" | sed 's@.*UIDesigner {\(.*\)"}.*@\1@g' | sed 's@.*version "\(.*\)@\1@g'`
-	echo "WEB_PAGES_UID_VERSION: ${WEB_PAGES_UID_VERSION}"
+    WEB_PAGES_UID_VERSION=`echo "${webPagesGradleBuild}" | tr -s "[:blank:]" | tr -d "\n" | sed 's@.*UIDesigner {\(.*\)"}.*@\1@g' | sed 's@.*version "\(.*\)@\1@g'`
+    echo "WEB_PAGES_UID_VERSION: ${WEB_PAGES_UID_VERSION}"
 }
 
 

--- a/build-script.sh
+++ b/build-script.sh
@@ -371,7 +371,7 @@ detectWebPagesDependenciesVersions() {
 	echo "Detecting web-pages dependencies versions"
 	local webPagesGradleBuild=`curl -sS -X GET https://raw.githubusercontent.com/bonitasoft/bonita-web-pages/${BONITA_BPM_VERSION}/build.gradle`
 
-	WEB_PAGES_UID_VERSION=`echo "${webPagesGradleBuild}" | tr --squeeze-repeats "[:blank:]" | tr --delete "\n" | sed 's@.*UIDesigner {\(.*\)"}.*@\1@g' | sed 's@.*version "\(.*\)@\1@g'`
+	WEB_PAGES_UID_VERSION=`echo "${webPagesGradleBuild}" | tr -s "[:blank:]" | tr -d "\n" | sed 's@.*UIDesigner {\(.*\)"}.*@\1@g' | sed 's@.*version "\(.*\)@\1@g'`
 	echo "WEB_PAGES_UID_VERSION: ${WEB_PAGES_UID_VERSION}"
 }
 

--- a/build-script.sh
+++ b/build-script.sh
@@ -77,7 +77,7 @@ checkout() {
     # The artifact include Ant Maven plugin to update the platform.target file but it is not executed before Tycho is executed and read the incorrect URL.
     if [[ "$repository_name" == "bonita-studio" ]]; then
         echo "WARN: workaround on $repository_name - fix platform.target URL"
-        sed -i "" "s,${STUDIO_P2_URL_INTERNAL_TO_REPLACE},${STUDIO_P2_URL},g" platform/platform.target
+        sed -i.bak "s,${STUDIO_P2_URL_INTERNAL_TO_REPLACE},${STUDIO_P2_URL},g" platform/platform.target
     fi
 }
 


### PR DESCRIPTION
Previous testings has shown that the existing script allows to build on Windows at the price of commenting some parts only required for Linux.
With this PR, I propose to let the script detect the OS and skip the Linux specific actions to make it work out of the box on other OS.

- [x] windows tests ✅
  - git bash `2.20.0.windows.1` --> `MINGW64_NT-10.0  2.11.2(0.329/5/3) 2018-11-10 14:38 x86_64 Msys`
  - Windows `10 Pro 1903 18362.418`
  - Java `Java version: 1.8.0_212, vendor: AdoptOpenJDK`
  - Default locale: `fr_FR, platform encoding: Cp1252`
```
Build is running on Windows/MINGW
> Using Maven version: 3.6.0
> Using curl version: 7.62.0
Check if Java version is compatible with Bonita
> JAVA_HOME is set
> Java command path is C:\Program Files\Java\jdk8u212-b04/bin/java
> Java full version: 1.8.0_212
> Java version: 8
```
- [ ] mac tests
- [x] linux tests (waiting for our Travis CI friend 😺 )
