### PR TITLE
fix(travis): avoid 'too long build' error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,6 @@ jdk: openjdk8
 os: linux
 dist: xenial
 
-# for studio build
-# see https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-services
-services:
-  - xvfb
-
-before_cache:
-  # Maven: ensure that we do not keep bonitasoft artifacts across builds
-  - rm -rf $HOME/.m2/repository/org/bonitasoft
-  # Gradle: see https://docs.travis-ci.com/user/languages/java/#projects-using-gradle
-  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
-  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
 cache:
   directories:
     # Maven dependencies and wrappers
@@ -22,6 +11,7 @@ cache:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
 
+
 branches:
   only:
   - master
@@ -29,17 +19,39 @@ branches:
 
 env:
   global:
-    - SCRIPT_BUILD_NO_CLEAN=true
-    - SCRIPT_BUILD_QUIET=true
+    - BONITA_BUILD_NO_CLEAN=true
 
-install:
-  # openjdk11 should be installed
-  # https://docs.travis-ci.com/user/reference/xenial/#jvm-clojure-groovy-java-scala-support
-  - /usr/local/lib/jvm/openjdk11/bin/java --version
-before_script:
-  # copy maven toolchains.xml configuration file
-  - ls -lh $HOME/.m2
-  - cp  .travis/maven/toolchains.xml $HOME/.m2/
-  - ls -lh $HOME/.m2
-# see https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received
-script: travis_wait 75 ./build-script.sh
+
+jobs:
+  include:
+    - stage: build without studio
+      before_cache:
+        # Gradle: see https://docs.travis-ci.com/user/languages/java/#projects-using-gradle
+        - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+        - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+      before_script:
+        # Maven: ensure that we do not keep bonitasoft artifacts across builds
+        # They are not removed from the cache (via before_cache) as they are required by the Studio job
+        - rm -rf $HOME/.m2/repository/org/bonitasoft
+        # do not declare environment variables in the env section to ensure the cache is shared by jobs
+        # see https://docs.travis-ci.com/user/caching/#caches-and-build-matrices
+        - export BONITA_BUILD_QUIET=true
+        - export BONITA_BUILD_STUDIO_SKIP=true
+      script: ./build-script.sh
+    - stage: build studio
+      # see https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-services
+      services:
+        - xvfb
+      install:
+        # openjdk11 should be installed
+        # https://docs.travis-ci.com/user/reference/xenial/#jvm-clojure-groovy-java-scala-support
+        - /usr/local/lib/jvm/openjdk11/bin/java --version
+        - export BONITA_BUILD_QUIET=false
+        - export BONITA_BUILD_STUDIO_ONLY=true
+      before_cache:
+        # remove studio-only configuration
+        - rm -f  $HOME/.m2/toolchains.xml
+      before_script:
+        # studio-only configuration
+        - cp .travis/maven/toolchains.xml $HOME/.m2/
+      script: ./build-script.sh


### PR DESCRIPTION
The Travis build previously failed with 'The job exceeded the maximum time
limit for jobs, and has been terminated'

The Travis build is now split into 2 jobs
  - 1st we build everything but the Studio
  - then build the Studio
Some tricks have been introduced to ensure that the 2 jobs can share the
same cache, in particular, on environment variables declaration.

The build script has been updated to allow to build only the Studio or
skip the Studio build.
As part of this update, the build configuration environment variable names
have changed: they are now prefixed by 'BONITA' instead of 'SCRIPT' for
consistency and better understanding