### PR TITLE
logs: provide more build info

### DIFF
--- a/build-script.sh
+++ b/build-script.sh
@@ -293,23 +293,28 @@ checkPrerequisites() {
 
 checkJavaVersion() {
     local JAVA_CMD=
-    echo "Check if Java version is compatible with Bonita"
+    echo "  > Java prerequisites"
+    echo "      Check if Java version is compatible with Bonita"
 
     if [[ "x$JAVA" = "x" ]]; then
         if [[ "x$JAVA_HOME" != "x" ]]; then
-            echo "  > JAVA_HOME is set"
+            echo "      JAVA_HOME is set"
             JAVA_CMD="$JAVA_HOME/bin/java"
         else
-            echo "  > JAVA_HOME is not set. Use java in path"
+            echo "      JAVA_HOME is not set. Use java in path"
             JAVA_CMD="java"
         fi
     else
-        JAVA_CMD=$JAVA
+        JAVA_CMD=${JAVA}
     fi
-    echo "  > Java command path is $JAVA_CMD"
+    echo "      Java command path is $JAVA_CMD"
+
+    java_full_version_details=$("$JAVA_CMD" -version 2>&1)
+    echo "      JVM details"
+    echo "${java_full_version_details}" | xargs -L 1 -I % echo "        %"
 
     java_full_version=$("$JAVA_CMD" -version 2>&1 | grep -i version | sed 's/.*version "\(.*\)".*$/\1/g')
-    echo "  > Java full version: $java_full_version"
+    echo "      Java full version: $java_full_version"
     if [[ "x$java_full_version" = "x" ]]; then
       echo "No Java command could be found. Please set JAVA_HOME variable to a JDK and/or add the java executable to your PATH"
       exit 1
@@ -323,13 +328,13 @@ checkJavaVersion() {
     else
       java_version=${java_version_1st_digit}
     fi
-    echo "  > Java version: $java_version"
+    echo "      Java version: $java_version"
 
     if [[ "$java_version" -ne "$java_version_expected" ]]; then
       echo "Invalid Java version $java_version not $java_version_expected. Please set JAVA_HOME environment variable to a valid JDK version, and/or add the java executable to your PATH"
       exit 1
     fi
-    echo "Java version is compatible"
+    echo "      Java version is compatible with Bonita"
 }
 
 

--- a/build-script.sh
+++ b/build-script.sh
@@ -229,16 +229,13 @@ logBuildInfo() {
     echo "OS information"
     if [[ "${OS_IS_LINUX}" == "true" ]]; then
         echo "  > Run on Linux"
-        echo "$(cat /etc/lsb-release)"
+        echo "$(cat /etc/lsb-release)" | xargs -L 1 -I % echo "      %"
     elif [[ "${OS_IS_MAC}" == "true" ]]; then
         echo "  > Run on MacOS"
-        echo "$(sw_vers)"
-    elif [[ "${OS_IS_WINDOWS}" == "true" ]]; then
-        echo "  > Run on Windows"
-        echo "  > Details: $(wmic os get Caption,Version,osarchitecture | grep Microsoft)"
+        echo "$(sw_vers)" | xargs -L 1 -I % echo "      %"
     else
-        echo "/!\ unable to find the OS type"
-        exit 1
+        echo "  > Run on Windows"
+        echo "$(wmic os get Caption,OSArchitecture,Version //value)" | xargs -L 1 --no-run-if-empty -I % echo "      %" | grep -v -e '^[[:space:]]*$'
     fi
     echo "  > Generic information: $(uname -a)"
 


### PR DESCRIPTION
Always display the following prior running the build
  - version of the git tool
  - info about the OS
  - commit of this project used to build

Example of generated logs (on windows)
```
OS information
  > Run on Windows
  > Details: Microsoft Windows 10 Pro  64-bit          10.0.18362
  > Generic information: MINGW64_NT-10.0-18362 DESKTOP-TOMA 3.0.7-338.x86_64 2019-07-03 15:16 UTC x86_64 Msys
Build environment
  > Use git version 2.23.0.windows.1
  > Commit: 10d55f61e6d9b80b4b16f169114bfd4be4ecbffb
Build settings
  > BONITA_BPM_VERSION: 7.9.4
  > BONITA_BUILD_NO_CLEAN: false
  > BONITA_BUILD_QUIET: false
  > BONITA_BUILD_STUDIO_ONLY: false
  > BONITA_BUILD_STUDIO_SKIP: false
Prerequisites
  > Use Maven version: 3.6.0
  > Use curl version: 7.65.3
Check if Java version is compatible with Bonita
  > JAVA_HOME is set
  > Java command path is C:\Program Files\Java\jdk8u192-b12/bin/java
  > Java full version: 1.8.0_192
  > Java version: 8
Java version is compatible
```