### PR TITLE
Introduce Github Actions for MacOS and Windows builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+name: MacOS and Windows Build
+
+on:
+  push:
+    branches:
+    - master
+    - dev
+  pull_request:
+    branches:
+    - master
+    - dev
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os.name }}
+    strategy:
+      matrix:
+        # syntax inspired from https://github.community/t5/GitHub-Actions/Using-a-matrix-defined-input-for-a-custom-action/m-p/32032/highlight/true#M988
+        os:
+          - {name: macos-latest, short: "macos" }
+          - {name: windows-latest, short: "windows" }
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Setup JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Setup Maven configuration
+      shell: bash
+      run: |
+        mkdir -p $HOME/.m2/
+        cp $GITHUB_WORKSPACE/.github/workflows/maven/settings.xml $HOME/.m2/
+    - name: Build without Studio
+      shell: bash
+      run: ./build-script.sh
+      env:
+        BONITA_BUILD_QUIET: true
+        BONITA_BUILD_STUDIO_SKIP: true
+    # TODO see if we can create an action for bundle/studio artifact preparation and upload
+    - name: Prepare Bonita bundle for upload
+      shell: bash
+      run: |
+        mkdir -p artifacts/bundle
+        cp bonita-distrib/bundle/tomcat/target/*.zip artifacts/bundle/
+        ls -lh artifacts/bundle/
+    - name: Upload Bonita bundle
+      # see https://help.github.com/en/github/automating-your-workflow-with-github-actions/persisting-workflow-data-using-artifacts and https://github.com/actions/upload-artifact
+      uses: actions/upload-artifact@master
+      with:
+        # see https://github.community/t5/GitHub-Actions/Use-variables-in-upload-artifact/m-p/34778#M2009
+        name: bonita-bundle-${{matrix.os.short}}-build-${{github.sha}}
+        path: artifacts/bundle/
+    - name: Build Studio
+      shell: bash
+      run: ./build-script.sh
+      env:
+        BONITA_BUILD_QUIET: true
+        BONITA_BUILD_STUDIO_ONLY: true
+    - name: Prepare Bonita Studio for upload
+      shell: bash
+      run: |
+        mkdir -p artifacts/studio
+        cp bonita-studio/all-in-one/target/*.zip artifacts/studio/
+        ls -lh artifacts/studio/
+    - name: Upload Bonita Studio
+      # see https://github.com/actions/upload-artifact
+      uses: actions/upload-artifact@master
+      with:
+        name: bonita-studio-${{matrix.os.short}}-build-${{github.sha}}
+        path: artifacts/studio/

--- a/.github/workflows/maven/settings.xml
+++ b/.github/workflows/maven/settings.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+    <mirrors>
+        <mirror>
+            <id>google-maven-central</id>
+            <name>Google Maven Central</name>
+            <url>https://maven-central.storage-download.googleapis.com/repos/central/data</url>
+            <mirrorOf>central</mirrorOf>
+        </mirror>
+        <!-- seems required in github action for Windows -->
+        <mirror>
+            <id>mirror-unknown-bonita-web-declared-repositories</id>
+            <name>Maven Central to replace wrongly declared repositories in bonita-web</name>
+            <url>https://maven-central.storage-download.googleapis.com/repos/central/data</url>
+            <!-- IMPORTANT: do not put spaces after comma otherwise repository is not considered -->
+            <mirrorOf>gwt-maven-plugins-nexus,oauth</mirrorOf>
+        </mirror>
+    </mirrors>
+
+</settings>

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ Build Bonita from sources
 
 [![Linux build](https://img.shields.io/travis/Bonitasoft-Community/Build-Bonita/master?label=Linux%20build&logo=travis)](https://travis-ci.org/Bonitasoft-Community/Build-Bonita)
 
+[![MacOS and Windows build](https://github.com/Bonitasoft-Community/Build-Bonita/workflows/MacOS%20and%20Windows%20Build/badge.svg)](https://github.com/Bonitasoft-Community/Build-Bonita/actions)
+
 
 Overview
 ------------------------------------------------------------------------------
@@ -14,7 +16,7 @@ Requirements
 ------------
 
 - Disk space: around 15 GB free space. Around 4 GB of dependencies will be downloaded (sources, Maven dependencies, ...). A fast internet connection is recommended.
-- OS: this script is designed for Linux Operating System. It is not regularly tested on Windows or Mac but should work on these OS.
+- OS: Linux, MacOS and Windows (see test environments list below)
 - Maven: 3.6.x.
 - Java: Oracle/OpenJDK Java 8 (⚠ you cannot use Java 11 to build Bonita).
 
@@ -23,7 +25,7 @@ Requirements
 Instructions
 ------------
 1. Place this script in an empty folder
-1. Run `bash build-script.sh` in a terminal
+1. Run `bash build-script.sh` in a terminal (on Windows, use git-bash as terminal i.e. the bash shell included with Git for Windows)
 1. Once finished, the following binaries are available
     1. studio: `bonita-studio/all-in-one/target` (only zip archive, no installer)
     1. tomcat bundle: `bonita-distrib/bundle/tomcat/target`
@@ -45,7 +47,7 @@ find -type d -name target -prune -exec rm -rf {} \;
 - The script does not produce Studio installers (required license for proprietary software).
 
 
-Test environment
+Test environments
 ----------------
 
 This script has been manually tested with the following environment:
@@ -54,7 +56,11 @@ This script has been manually tested with the following environment:
 - Oracle Java 1.8.0_221
 
 
-In addition, a Travis CI Ubuntu Xenial build runs on master branch push and PR creation/update
+In addition, CI builds are run on master/dev branch push and Pull Requests (see badges on top of this page)
+- Linux: Ubuntu Xenial (Travis CI)
+- MacOS: Catalina (Github Action)
+- Windows: Windows Server 2019 Datacenter (Github Action)
+
 
 Issues
 ------


### PR DESCRIPTION
Add a single actions for the 2 os
Upload Bundle and Studio built artifacts to the actions

Add a specific maven settings to
  - use google mirror for central (US mirror)
    - we faced connection timeouts with central
    Could not transfer artifact org.apache.maven.shared:maven-filtering:pom:1.0-beta-4 from/to central (https://repo.maven.apache.org/maven2): Connection reset
    - so we do see like Travis CI
    See https://cloudplatform.googleblog.com/2015/11/faster-builds-for-Java-developers-with-Maven-Central-mirror.html
  - mirror bonita-web unknown repositories to maven central (this won't
  be needed as of Bonita 7.10)