### PR TITLE
[dev] Introduce GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+name: MacOS and Windows Build
+
+on:
+  push:
+    branches:
+    - master
+    - dev
+  pull_request:
+    branches:
+    - master
+    - dev
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os.name }}
+    strategy:
+      matrix:
+        # syntax inspired from https://github.community/t5/GitHub-Actions/Using-a-matrix-defined-input-for-a-custom-action/m-p/32032/highlight/true#M988
+        os:
+          - {name: macos-latest, short: "macos" }
+          - {name: windows-latest, short: "windows" }
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Setup JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Setup Maven configuration
+      shell: bash
+      run: |
+        mkdir -p $HOME/.m2/
+        cp $GITHUB_WORKSPACE/.github/workflows/maven/settings.xml $HOME/.m2/
+    - name: Build without Studio
+      shell: bash
+      run: ./build-script.sh
+      env:
+        BONITA_BUILD_QUIET: true
+        BONITA_BUILD_STUDIO_SKIP: true
+    # TODO see if we can create an action for bundle/studio artifact preparation and upload
+    - name: Prepare Bonita bundle for upload
+      shell: bash
+      run: |
+        mkdir -p artifacts/bundle
+        cp bonita-distrib/bundle/tomcat/target/*.zip artifacts/bundle/
+        ls -lh artifacts/bundle/
+    - name: Upload Bonita bundle
+      # see https://help.github.com/en/github/automating-your-workflow-with-github-actions/persisting-workflow-data-using-artifacts and https://github.com/actions/upload-artifact
+      uses: actions/upload-artifact@master
+      with:
+        # see https://github.community/t5/GitHub-Actions/Use-variables-in-upload-artifact/m-p/34778#M2009
+        name: bonita-bundle-${{matrix.os.short}}-build-${{github.sha}}
+        path: artifacts/bundle/
+    - name: Build Studio
+      shell: bash
+      run: ./build-script.sh
+      env:
+        BONITA_BUILD_QUIET: true
+        BONITA_BUILD_STUDIO_ONLY: true
+    - name: Prepare Bonita Studio for upload
+      shell: bash
+      run: |
+        mkdir -p artifacts/studio
+        cp bonita-studio/all-in-one/target/*.zip artifacts/studio/
+        ls -lh artifacts/studio/
+    - name: Upload Bonita Studio
+      # see https://github.com/actions/upload-artifact
+      uses: actions/upload-artifact@master
+      with:
+        name: bonita-studio-${{matrix.os.short}}-build-${{github.sha}}
+        path: artifacts/studio/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
   build:
     runs-on: ${{ matrix.os.name }}
     strategy:
+      # we want to run the full build on all os: don't cancel running jobs even if one fails
+      fail-fast: false
       matrix:
         # syntax inspired from https://github.community/t5/GitHub-Actions/Using-a-matrix-defined-input-for-a-custom-action/m-p/32032/highlight/true#M988
         os:
@@ -42,7 +44,7 @@ jobs:
       shell: bash
       run: |
         mkdir -p artifacts/bundle
-        cp bonita-distrib/bundle/tomcat/target/*.zip artifacts/bundle/
+        cp bonita-distrib/tomcat/target/*.zip artifacts/bundle/
         ls -lh artifacts/bundle/
     - name: Upload Bonita bundle
       # see https://help.github.com/en/github/automating-your-workflow-with-github-actions/persisting-workflow-data-using-artifacts and https://github.com/actions/upload-artifact

--- a/.github/workflows/maven/settings.xml
+++ b/.github/workflows/maven/settings.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+    <mirrors>
+        <mirror>
+            <id>google-maven-central</id>
+            <name>Google Maven Central</name>
+            <url>https://maven-central.storage-download.googleapis.com/repos/central/data</url>
+            <mirrorOf>central</mirrorOf>
+        </mirror>
+        <!-- seems required in github action for Windows -->
+        <mirror>
+            <id>mirror-unknown-bonita-web-declared-repositories</id>
+            <name>Maven Central to replace wrongly declared repositories in bonita-web</name>
+            <url>https://maven-central.storage-download.googleapis.com/repos/central/data</url>
+            <!-- IMPORTANT: do not put spaces after comma otherwise repository is not considered -->
+            <mirrorOf>gwt-maven-plugins-nexus,oauth</mirrorOf>
+        </mirror>
+    </mirrors>
+
+</settings>

--- a/.github/workflows/maven/settings.xml
+++ b/.github/workflows/maven/settings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
-
     <mirrors>
         <mirror>
             <id>google-maven-central</id>
@@ -9,14 +8,5 @@
             <url>https://maven-central.storage-download.googleapis.com/repos/central/data</url>
             <mirrorOf>central</mirrorOf>
         </mirror>
-        <!-- seems required in github action for Windows -->
-        <mirror>
-            <id>mirror-unknown-bonita-web-declared-repositories</id>
-            <name>Maven Central to replace wrongly declared repositories in bonita-web</name>
-            <url>https://maven-central.storage-download.googleapis.com/repos/central/data</url>
-            <!-- IMPORTANT: do not put spaces after comma otherwise repository is not considered -->
-            <mirrorOf>gwt-maven-plugins-nexus,oauth</mirrorOf>
-        </mirror>
     </mirrors>
-
 </settings>

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ Build Bonita from sources
 
 [![Linux build](https://img.shields.io/travis/Bonitasoft-Community/Build-Bonita/master?label=Linux%20build&logo=travis)](https://travis-ci.org/Bonitasoft-Community/Build-Bonita)
 
+[![MacOS and Windows build](https://github.com/Bonitasoft-Community/Build-Bonita/workflows/MacOS%20and%20Windows%20Build/badge.svg)](https://github.com/Bonitasoft-Community/Build-Bonita/actions)
+
 
 Overview
 ------------------------------------------------------------------------------
@@ -14,7 +16,7 @@ Requirements
 ------------
 
 - Disk space: around 15 GB free space. Around 4 GB of dependencies will be downloaded (sources, Maven dependencies, ...). A fast internet connection is recommended.
-- OS: this script is designed for Linux Operating System. It is not regularly tested on Windows or Mac but should work on these OS.
+- OS: Linux, MacOS and Windows (see test environments list below)
 - Maven: 3.6.x.
 - Java: Oracle/OpenJDK Java 8 (⚠ you cannot use Java 11 to build Bonita).
 
@@ -27,7 +29,7 @@ Instructions
     1. build from the `master` branch which contains latest build improvements for the latest Bonita version available
     1. alternatively, you can checkout a tag, if you want to build past version for instance
     1. if you want to give a try to the development version of Bonita, build from the `dev` branch
-1. Run `bash build-script.sh` in a terminal
+1. Run `bash build-script.sh` in a terminal (on Windows, use git-bash as terminal i.e. the bash shell included with Git for Windows)
 1. Once finished, the following binaries are available
     1. studio: `bonita-studio/all-in-one/target` (only zip archive, no installer)
     1. tomcat bundle: `bonita-distrib/tomcat/target`
@@ -49,7 +51,7 @@ find -type d -name target -prune -exec rm -rf {} \;
 - The script does not produce Studio installers (required license for proprietary software).
 
 
-Test environment
+Test environments
 ----------------
 
 This script has been manually tested with the following environment:
@@ -58,7 +60,11 @@ This script has been manually tested with the following environment:
 - Oracle Java 1.8.0_221
 
 
-In addition, a Travis CI Ubuntu Xenial build runs on master/dev branches push and PR creation/update
+In addition, CI builds are run on master/dev branch push and Pull Requests (see badges on top of this page)
+- Linux: Ubuntu Xenial (Travis CI)
+- MacOS: Catalina (Github Actions)
+- Windows: Windows Server 2019 Datacenter (Github Actions)
+
 
 Issues
 ------


### PR DESCRIPTION
WIP: this should fail at the artifact bundle upload as the bundle path changed in 7.10

In addition, do not fail-fast the matrix job to ensure windows and macos builds always run to the end (otherwise, when a matrix part fails, the others are cancelled). This will let us know if an issue occurs only on an OS or both 