### PR TITLE
[dev] simplify maven build calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,7 @@ find -type d -name target -prune -exec rm -rf {} \;
 
 ## Test environments
 
-This script has been manually tested with the following environment:
-- Debian GNU/Linux Buster
-- Maven 3.6.0
-- Oracle Java 1.8.0_221
-
-
-In addition, CI builds are run on push to master/dev branches and Pull Requests (see badges on top of this page)
+CI builds are run on push to master/dev branches and Pull Requests (see badges on top of this page)
 - Linux: Ubuntu Xenial (Travis CI)
 - MacOS: Catalina (Github Actions)
 - Windows: Windows Server 2019 DataCenter (Github Actions)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ the Bonita Studio.
 - Disk space: around 15 GB free space. Around 4 GB of dependencies will be downloaded (sources, 3rd party dependencies,
 ...). A fast internet connection is recommended.
 - OS: Linux, MacOS and Windows (see test environments list below)
-- Maven: 3.6.x.
 - Java: Oracle/OpenJDK Java 8 (⚠ you cannot use Java 11 to build Bonita).
 
 

--- a/build-script.sh
+++ b/build-script.sh
@@ -165,10 +165,6 @@ build_maven_wrapper_verify_skiptest_with_profile()
 build_maven_wrapper_install_skiptest()
 {
     checkout "$@"
-    # FIXME: required to build UID
-    # This has been fixed in UID 1.9.56, see https://github.com/bonitasoft/bonita-ui-designer/commit/edf0a0c7f943e8f215890550247d61eba14932c6
-    # To be removed when we will build newest UID versions
-    chmod u+x mvnw
     build_maven_wrapper
     build_quiet_if_requested
     clean

--- a/build-script.sh
+++ b/build-script.sh
@@ -145,20 +145,6 @@ profile() {
     build_command="$build_command -P$1"
 }
 
-#FIXME: should be replaced in all projects by Maven wrapper
-# params:
-# - Git repository name
-# - Branch name (optional)
-build_maven_install_skiptest() {
-    checkout "$@"
-    build_maven
-    build_quiet_if_requested
-    clean
-    install
-    skiptest
-    run_maven_with_standard_system_properties
-}
-
 # params:
 # - Git repository name
 # - Profile name

--- a/build-script.sh
+++ b/build-script.sh
@@ -89,11 +89,6 @@ run_gradle_with_standard_system_properties() {
     cd ..
 }
 
-# FIXME: should be replaced in all project by Maven wrapper
-build_maven() {
-    build_command="mvn"
-}
-
 build_maven_wrapper() {
     build_command="./mvnw"
 }
@@ -239,16 +234,6 @@ checkPrerequisites() {
             fi
             echo "  > X server running correctly"
         fi
-    fi
-
-    # Test that Maven exists
-    # FIXME: remove once all projects includes Maven wrapper
-    if hash mvn 2>/dev/null; then
-        MAVEN_VERSION="$(mvn --version 2>&1 | awk -F " " 'NR==1 {print $3}')"
-        echo "  > Use Maven version: $MAVEN_VERSION"
-    else
-        echo "Maven not found. Exiting."
-        exit 1
     fi
 
     # Test if Curl exists


### PR DESCRIPTION
In build script:
- remove unused 'build_maven_install_skiptest' function
- no need to make mvnw executable in 'build_maven_wrapper_install_skiptest'