### PR TITLE
[dev] Add support for Bonita 2021.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,10 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v1
-    - name: Setup JDK 1.8
+    - name: Setup JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
     - name: Setup Maven configuration
       shell: bash
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       shell: bash
       run: ./build-script.sh
       env:
-        BONITA_BUILD_QUIET: true
+        BONITA_BUILD_QUIET: fakse
         BONITA_BUILD_STUDIO_SKIP: true
     - name: Upload Bonita bundle
       # see https://help.github.com/en/github/automating-your-workflow-with-github-actions/persisting-workflow-data-using-artifacts and https://github.com/actions/upload-artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       shell: bash
       run: ./build-script.sh
       env:
-        BONITA_BUILD_QUIET: fakse
+        BONITA_BUILD_QUIET: true
         BONITA_BUILD_STUDIO_SKIP: true
     - name: Upload Bonita bundle
       # see https://help.github.com/en/github/automating-your-workflow-with-github-actions/persisting-workflow-data-using-artifacts and https://github.com/actions/upload-artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v1
-    - name: Setup JDK 11
+    - name: Setup JDK
       uses: actions/setup-java@v1
       with:
         java-version: 11

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-jdk: openjdk8
+jdk: openjdk11
 os: linux
 dist: bionic
 

--- a/build-script.sh
+++ b/build-script.sh
@@ -18,7 +18,7 @@ BONITA_BUILD_STUDIO_SKIP=${BONITA_BUILD_STUDIO_SKIP:-false}
 
 # Bonita version
 
-BONITA_VERSION=7.13.0.W36-03
+BONITA_VERSION=7.13.0.W36
 
 
 ########################################################################################################################

--- a/build-script.sh
+++ b/build-script.sh
@@ -307,6 +307,15 @@ detectWebPagesDependenciesVersions() {
     echo "WEB_PAGES_UID_VERSION: ${WEB_PAGES_UID_VERSION}"
 }
 
+detectStudioDependenciesVersions() {
+	echoHeaders "Detecting Studio dependencies versions"
+	local studioPom=`curl -sS -X GET https://raw.githubusercontent.com/bonitasoft/bonita-studio/${BONITA_VERSION}/pom.xml`
+
+    STUDIO_UID_VERSION=`echo "${studioPom}" | grep ui.designer.version | sed 's@.*>\(.*\)<.*@\1@g'`
+    echo "STUDIO_UID_VERSION: ${STUDIO_UID_VERSION}"
+}
+
+
 
 ########################################################################################################################
 # MAIN
@@ -375,6 +384,7 @@ fi
 
 if [[ "${BONITA_BUILD_STUDIO_SKIP}" == "false" ]]; then
     build_maven_wrapper_install_skiptest bonita-data-repository
+    build_maven_wrapper_install_skiptest bonita-ui-designer ${STUDIO_UID_VERSION}
     build_maven_wrapper_verify_skiptest_with_profile bonita-studio default,all-in-one,!jdk11-tests
 else
     echoHeaders "Skipping the Studio build"

--- a/build-script.sh
+++ b/build-script.sh
@@ -18,7 +18,7 @@ BONITA_BUILD_STUDIO_SKIP=${BONITA_BUILD_STUDIO_SKIP:-false}
 
 # Bonita version
 
-BONITA_VERSION=7.13.0.W36-02
+BONITA_VERSION=7.13.0.W36-03
 
 
 ########################################################################################################################

--- a/build-script.sh
+++ b/build-script.sh
@@ -18,7 +18,7 @@ BONITA_BUILD_STUDIO_SKIP=${BONITA_BUILD_STUDIO_SKIP:-false}
 
 # Bonita version
 
-BONITA_VERSION=7.13.0.W38
+BONITA_VERSION=7.13.0.W36
 
 
 ########################################################################################################################

--- a/build-script.sh
+++ b/build-script.sh
@@ -18,7 +18,7 @@ BONITA_BUILD_STUDIO_SKIP=${BONITA_BUILD_STUDIO_SKIP:-false}
 
 # Bonita version
 
-BONITA_VERSION=7.13.0.beta-02
+BONITA_VERSION=7.13.0.W35
 
 
 ########################################################################################################################

--- a/build-script.sh
+++ b/build-script.sh
@@ -18,7 +18,7 @@ BONITA_BUILD_STUDIO_SKIP=${BONITA_BUILD_STUDIO_SKIP:-false}
 
 # Bonita version
 
-BONITA_VERSION=7.13.0.W35
+BONITA_VERSION=7.13.0.W36
 
 
 ########################################################################################################################

--- a/build-script.sh
+++ b/build-script.sh
@@ -362,6 +362,11 @@ if [[ "${BONITA_BUILD_STUDIO_ONLY}" == "false" ]]; then
     build_maven_wrapper_install_skiptest bonita-ui-designer ${WEB_PAGES_UID_VERSION}
     build_gradle_wrapper_test_skip_publishToMavenLocal bonita-web-pages
 
+    build_maven_wrapper_install_skiptest bonita-application-directory
+    build_maven_wrapper_install_skiptest bonita-user-application
+    build_maven_wrapper_install_skiptest bonita-admin-application
+    build_maven_wrapper_install_skiptest bonita-super-admin-application
+
     build_maven_wrapper_install_skiptest bonita-distrib
 
 else

--- a/build-script.sh
+++ b/build-script.sh
@@ -18,7 +18,7 @@ BONITA_BUILD_STUDIO_SKIP=${BONITA_BUILD_STUDIO_SKIP:-false}
 
 # Bonita version
 
-BONITA_VERSION=7.12.0
+BONITA_VERSION=7.13.0.beta-02
 
 
 ########################################################################################################################

--- a/build-script.sh
+++ b/build-script.sh
@@ -18,7 +18,7 @@ BONITA_BUILD_STUDIO_SKIP=${BONITA_BUILD_STUDIO_SKIP:-false}
 
 # Bonita version
 
-BONITA_VERSION=7.13.0.W36
+BONITA_VERSION=7.13.0.W38
 
 
 ########################################################################################################################

--- a/build-script.sh
+++ b/build-script.sh
@@ -18,7 +18,7 @@ BONITA_BUILD_STUDIO_SKIP=${BONITA_BUILD_STUDIO_SKIP:-false}
 
 # Bonita version
 
-BONITA_VERSION=7.13.0.W36
+BONITA_VERSION=7.13.0.W36-02
 
 
 ########################################################################################################################
@@ -300,16 +300,16 @@ checkJavaVersion() {
 ########################################################################################################################
 
 detectWebPagesDependenciesVersions() {
-	echoHeaders "Detecting web-pages dependencies versions"
-	local webPagesGradleBuild=`curl -sS -X GET https://raw.githubusercontent.com/bonitasoft/bonita-web-pages/${BONITA_VERSION}/build.gradle`
+    echoHeaders "Detecting web-pages dependencies versions"
+    local webPagesGradleBuild=`curl -sS -X GET https://raw.githubusercontent.com/bonitasoft/bonita-web-pages/${BONITA_VERSION}/build.gradle`
 
     WEB_PAGES_UID_VERSION=`echo "${webPagesGradleBuild}" | tr -s "[:blank:]" | tr -d "\n" | sed 's@.*UIDesigner {\(.*\)"}.*@\1@g' | sed 's@.*version "\(.*\)@\1@g'`
     echo "WEB_PAGES_UID_VERSION: ${WEB_PAGES_UID_VERSION}"
 }
 
 detectStudioDependenciesVersions() {
-	echoHeaders "Detecting Studio dependencies versions"
-	local studioPom=`curl -sS -X GET https://raw.githubusercontent.com/bonitasoft/bonita-studio/${BONITA_VERSION}/pom.xml`
+    echoHeaders "Detecting Studio dependencies versions"
+    local studioPom=`curl -sS -X GET https://raw.githubusercontent.com/bonitasoft/bonita-studio/${BONITA_VERSION}/pom.xml`
 
     STUDIO_UID_VERSION=`echo "${studioPom}" | grep ui.designer.version | sed 's@.*>\(.*\)<.*@\1@g'`
     echo "STUDIO_UID_VERSION: ${STUDIO_UID_VERSION}"

--- a/build-script.sh
+++ b/build-script.sh
@@ -311,7 +311,7 @@ detectStudioDependenciesVersions() {
     echoHeaders "Detecting Studio dependencies versions"
     local studioPom=`curl -sS -X GET https://raw.githubusercontent.com/bonitasoft/bonita-studio/${BONITA_VERSION}/pom.xml`
 
-    STUDIO_UID_VERSION=`echo "${studioPom}" | grep ui.designer.version | sed 's@.*>\(.*\)<.*@\1@g'`
+    STUDIO_UID_VERSION=`echo "${studioPom}" | grep \<ui.designer.version\> | sed 's@.*>\(.*\)<.*@\1@g'`
     echo "STUDIO_UID_VERSION: ${STUDIO_UID_VERSION}"
 }
 
@@ -377,7 +377,6 @@ if [[ "${BONITA_BUILD_STUDIO_ONLY}" == "false" ]]; then
     build_maven_wrapper_install_skiptest bonita-super-admin-application
 
     build_maven_wrapper_install_skiptest bonita-distrib
-
 else
     echoHeaders "Skipping all build prior the Studio part"
 fi

--- a/build-script.sh
+++ b/build-script.sh
@@ -18,7 +18,7 @@ BONITA_BUILD_STUDIO_SKIP=${BONITA_BUILD_STUDIO_SKIP:-false}
 
 # Bonita version
 
-BONITA_VERSION=7.13.0.W36
+BONITA_VERSION=7.13.0.W36-04
 
 
 ########################################################################################################################
@@ -366,7 +366,7 @@ if [[ "${BONITA_BUILD_STUDIO_ONLY}" == "false" ]]; then
     build_maven_wrapper_install_skiptest bonita-web
     build_maven_wrapper_install_skiptest bonita-portal-js
 
-    # bonita-web-pages is build using a specific version of UI Designer.
+    # bonita-web-pages uses a dedicated UID version
     detectWebPagesDependenciesVersions
     build_maven_wrapper_install_skiptest bonita-ui-designer ${WEB_PAGES_UID_VERSION}
     build_gradle_wrapper_test_skip_publishToMavenLocal bonita-web-pages
@@ -384,7 +384,11 @@ fi
 
 if [[ "${BONITA_BUILD_STUDIO_SKIP}" == "false" ]]; then
     build_maven_wrapper_install_skiptest bonita-data-repository
+    
+    # bonita-studio uses a dedicated UID version
+    detectStudioDependenciesVersions
     build_maven_wrapper_install_skiptest bonita-ui-designer ${STUDIO_UID_VERSION}
+    
     build_maven_wrapper_verify_skiptest_with_profile bonita-studio default,all-in-one,!jdk11-tests
 else
     echoHeaders "Skipping the Studio build"

--- a/build-script.sh
+++ b/build-script.sh
@@ -18,7 +18,7 @@ BONITA_BUILD_STUDIO_SKIP=${BONITA_BUILD_STUDIO_SKIP:-false}
 
 # Bonita version
 
-BONITA_VERSION=7.13.0.W36-04
+BONITA_VERSION=7.13.0.W36-05
 
 
 ########################################################################################################################

--- a/build-script.sh
+++ b/build-script.sh
@@ -278,7 +278,7 @@ checkJavaVersion() {
     fi
 
     java_version_1st_digit=$(echo "$java_full_version" | sed 's/\(.*\)\..*\..*$/\1/g')
-    java_version_expected=8
+    java_version_expected=11
     # pre Java 9 versions, get minor version
     if [[ "$java_version_1st_digit" -eq "1" ]]; then
       java_version=$(echo "$java_full_version" | sed 's/.*\.\(.*\)\..*$/\1/g')


### PR DESCRIPTION
- [x] 7.13.0-beta-02. GWT requires Java 8 to be configured when building bonita-web. Should be fixed in 7.13.0.W35
- [x] 7.13.0.W35 ~portal-js bower issue~ [Missing web-pages tag](https://github.com/Bonitasoft-Community/Build-Bonita/pull/78#issuecomment-913636990). Same problem with 7.13.0.W36. Tagged pushed, see also https://github.com/bonitasoft/bonita-web-pages/pull/88
- [x] missing apps that are required for bonita-distrib packaging
- [x] uid build needed for studio
- [x] failing command to retrieve the uid version in the studio pom
- [x] windows: error in bonita-web-pages build. Should be fixed in 7.13.0.W36+, https://github.com/bonitasoft/bonita-web-pages/commit/44326f42347129a5ae63bd65f099a2e40334f274
- [x] studio macos ang windows error on github runner: same root cause as for linux. The studio linux build on Travis is run in "non quiet" mode, so we have the full maven logs with more details.
- [x] studio linux error on travis linux runner. _Module org.bonitasoft.studio.local.repository_ `Non-resolvable import POM: Could not find artifact org.bonitasoft.runtime:bonita-runtime-bom:pom:7.13.0.W36-04`. This dependency (newly introduced in Bonita 2021.2) is not available when building the studio. **Fixed in 7.13.0.W36-05**, see https://github.com/bonitasoft/bonita-studio/commit/02e6ec2957f9da834a184553b423716dcd8feafc


<details>
<summary>7.13.0.W36-04 studio error on gh runner macos-10.15</summary>
<pre>
HEAD is now at 6b82bcc67a [STUDIO RELEASE] Prepare release 7.13.0.W36-04
Configure quiet build
[DEBUG] Running build command: ./mvnw --quiet clean verify -DskipTests -Pdefault,all-in-one,!jdk11-tests -Dengine.version=7.13.0.W36-04 -Dfilters.version=7.13.0.W36-04
Configure engine bundle
Enable rest api authorizations check debug mode
Set tomcat session cookie path to '/' for uid integration
Set hibernate slow query log level to WARN
Unable to create basic Accelerated OpenGL renderer.
Unable to create basic Accelerated OpenGL renderer.
Core Image is now using the software OpenGL renderer. This will be slow.
WARNING: GL pipe is running in software mode (Renderer ID=0x1020400)
Error:  Command execution failed.
org.apache.commons.exec.ExecuteException: Process exited with an error: 1 (Exit value: 1)
    at org.apache.commons.exec.DefaultExecutor.executeInternal (DefaultExecutor.java:404)
    at org.apache.commons.exec.DefaultExecutor.execute (DefaultExecutor.java:166)
    at org.codehaus.mojo.exec.ExecMojo.executeCommandLine (ExecMojo.java:982)
    at org.codehaus.mojo.exec.ExecMojo.executeCommandLine (ExecMojo.java:929)
    at org.codehaus.mojo.exec.ExecMojo.execute (ExecMojo.java:452)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:210)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:156)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:148)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:957)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:289)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:193)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:566)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:566)
    at org.apache.maven.wrapper.BootstrapMainStarter.start (BootstrapMainStarter.java:39)
    at org.apache.maven.wrapper.WrapperExecutor.execute (WrapperExecutor.java:122)
    at org.apache.maven.wrapper.MavenWrapperMain.main (MavenWrapperMain.java:55)
Error:  Failed to execute goal org.codehaus.mojo:exec-maven-plugin:3.0.0:exec (package-offline-repository) on project org.bonitasoft.studio.local.repository: Command execution failed.: Process exited with an error: 1 (Exit value: 1) -> [Help 1]
</pre>
</details>

<details>
<summary>7.13.0.W36-04 studio error on gh runner windows-2019</summary>
<pre>
HEAD is now at 6b82bcc67a [STUDIO RELEASE] Prepare release 7.13.0.W36-04
Configure quiet build
[DEBUG] Running build command: ./mvnw --quiet clean verify -DskipTests -Pdefault,all-in-one,!jdk11-tests -Dengine.version=7.13.0.W36-04 -Dfilters.version=7.13.0.W36-04
Configure engine bundle
Enable rest api authorizations check debug mode
Set tomcat session cookie path to '/' for uid integration
Set hibernate slow query log level to WARN
Error:  Command execution failed.
org.apache.commons.exec.ExecuteException: Process exited with an error: 1 (Exit value: 1)
    at org.apache.commons.exec.DefaultExecutor.executeInternal (DefaultExecutor.java:404)
    at org.apache.commons.exec.DefaultExecutor.execute (DefaultExecutor.java:166)
    at org.codehaus.mojo.exec.ExecMojo.executeCommandLine (ExecMojo.java:982)
    at org.codehaus.mojo.exec.ExecMojo.executeCommandLine (ExecMojo.java:929)
    at org.codehaus.mojo.exec.ExecMojo.execute (ExecMojo.java:452)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:210)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:156)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:148)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:957)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:289)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:193)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:566)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:566)
    at org.apache.maven.wrapper.BootstrapMainStarter.start (BootstrapMainStarter.java:39)
    at org.apache.maven.wrapper.WrapperExecutor.execute (WrapperExecutor.java:122)
    at org.apache.maven.wrapper.MavenWrapperMain.main (MavenWrapperMain.java:55)
Error:  Failed to execute goal org.codehaus.mojo:exec-maven-plugin:3.0.0:exec (package-offline-repository) on project org.bonitasoft.studio.local.repository: Command execution failed.: Process exited with an error: 1 (Exit value: 1) -> [Help 1]
</pre>
</details>


<details>
<summary>7.13.0.W35 portal-js bower log errors - can be ignored</summary>
<pre>
Unzipping /Users/runner/.m2/wrapper/dists/apache-maven-3.5.0-bin/6ps54u5pnnbbpr6ds9rppcc7iv/apache-maven-3.5.0-bin.zip to /Users/runner/.m2/wrapper/dists/apache-maven-3.5.0-bin/6ps54u5pnnbbpr6ds9rppcc7iv
Set executable permissions for: /Users/runner/.m2/wrapper/dists/apache-maven-3.5.0-bin/6ps54u5pnnbbpr6ds9rppcc7iv/apache-maven-3.5.0/bin/mvn
Error:  bower angular-file-upload#2.1.4          invalid-meta for:/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/runner/bower/e60440287b4df1cbc04045e77a8c05f5-19336-wf1g2H/bower.json
Error:  bower angular-file-upload#2.1.4          invalid-meta The "main" field cannot contain minified files
Error:  bower bootstrap-toggle#2.0.0             invalid-meta for:/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/runner/bower/0b929c0867c8110af5ff3e9b79f533aa-19336-64Lo3U/bower.json
Error:  bower bootstrap-toggle#2.0.0             invalid-meta The "main" field cannot contain minified files
Error:  bower bootstrap-toggle#2.0.0             invalid-meta The "main" field cannot contain minified files
Error:  bower bonita-js-components#0.5.24            mismatch Version declared in the json (0.5.23) is different than the resolved one (0.5.24)
Error:  bower jquery-resizable-columns#0.1.3     invalid-meta for:/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/runner/bower/2838104021538ec2d7d1b3c80aa5e1ea-19336-tGMKle/bower.json
Error:  bower jquery-resizable-columns#0.1.3     invalid-meta The "main" field cannot contain minified files
Error:  bower jquery-resizable-columns#0.1.3         mismatch Version declared in the json (0.1.0) is different than the resolved one (0.1.3)
Error:  bower angular-ui-tree#2.9.0              invalid-meta for:/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/runner/bower/321ae04a58376bbb1bbb1cdc593dae00-19336-7DmtDR/bower.json
Error:  bower angular-ui-tree#2.9.0              invalid-meta The "main" field cannot contain minified files
Error:  bower bootstrap-tags#1.1.5                   mismatch Version declared in the json (1.1.3) is different than the resolved one (1.1.5)
Error:  bower ngtoast#1.5.6                      invalid-meta for:/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/runner/bower/7282425600d1a6d677799001e902bee2-19336-v3sASO/bower.json
Error:  bower ngtoast#1.5.6                      invalid-meta The "name" is recommended to be lowercase, can contain digits, dots, dashes
Error:  bower json3#3.2.6                        invalid-meta for:/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/runner/bower/882f9a9d8dc064f78faf2428395f7a20-19336-bLsotM/bower.json
Error:  bower json3#3.2.6                        invalid-meta The "main" field cannot contain minified files
Error:  bower bootstrap#3.3.2                    invalid-meta for:/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/runner/bower/ca4c50b905dc21ea17a10549a6f5944f-19336-R24NW4/bower.json
Error:  bower bootstrap#3.3.2                    invalid-meta The "main" field cannot contain font, image, audio, or video files
Error:  bower bootstrap#3.3.2                    invalid-meta The "main" field cannot contain font, image, audio, or video files
Error:  bower bootstrap#3.3.2                    invalid-meta The "main" field cannot contain font, image, audio, or video files
Error:  bower bootstrap#3.3.2                    invalid-meta The "main" field cannot contain font, image, audio, or video files
</pre>
</details>

