### PR TITLE
tr: remove bonita-web-extensions from build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@ bonita-studio-watchdog
 bonita-studio
 bonita-ui-designer
 bonita-userfilters
-bonita-web-extensions
 bonita-web-pages
 bonita-web
 image-overlay-plugin

--- a/build-script.sh
+++ b/build-script.sh
@@ -394,8 +394,6 @@ echo
 if [[ "${BONITA_BUILD_STUDIO_ONLY}" == "false" ]]; then
     build_gradle_wrapper_test_skip_publishToMavenLocal bonita-engine
 
-    build_maven_wrapper_install_skiptest bonita-web-extensions
-
     build_maven_wrapper_install_skiptest bonita-web
     build_maven_wrapper_install_skiptest bonita-portal-js
 


### PR DESCRIPTION
As `bonita-web-extensions` will be merged into `bonita-engine`, we remove `bonita-web-extensions` from the community build.