### PR TITLE
chore(deps-gha): use bonitasoft/actions notify-slack@v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       - uses: technote-space/workflow-conclusion-action@v3
       - name: Send failure message to Slack channel
         if: ${{ github.event_name != 'pull_request' && env.WORKFLOW_CONCLUSION == 'failure'}}
-        uses: bonitasoft/actions/packages/notify-slack@main        
+        uses: bonitasoft/actions/packages/notify-slack@v1    
         with:
           CHANNEL_ID: ${{ secrets.CHANNEL_ID }}
           MESSAGE: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       - uses: technote-space/workflow-conclusion-action@v3
       - name: Send failure message to Slack channel
         if: ${{ github.event_name != 'pull_request' && env.WORKFLOW_CONCLUSION == 'failure'}}
-        uses: bonitasoft/actions/packages/notify-slack@v1    
+        uses: bonitasoft/actions/packages/notify-slack@v2
         with:
           CHANNEL_ID: ${{ secrets.CHANNEL_ID }}
           MESSAGE: |


### PR DESCRIPTION
Stop using the main branch and use a released version instead. The used action will be more stable and this will prevent breaking changes from occurring silently.

### Rationale

`bonitasoft/actions` provides generic `v1` tag, in addition to minor and patch tags (see https://github.com/bonitasoft/actions/releases/tag/v1.3.0). So this is now safer to stop using the `main` branch. The `v1` tag will allow to have action auto-update that the `main` branch provided but without potential breaking changes.

[UPDATE] Bump to v2 which is the latest major version of the action.

Dependabot will be able to update the actions on new major release, so we will aware of such changes (see a6e88d688c11ff0d42bef82cf0c53614f2a7a8c7).